### PR TITLE
Set minimum php version to 7.2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "php": "^7.2.5",
         "laravel/framework": "^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary

This PR adds a requirement for php `^7.2.5`